### PR TITLE
#1 - Update Term Meta Shape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 *.sql
 *.tar.gz
 *.zip
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ node_modules/
 *.sql
 *.tar.gz
 *.zip
-.idea
+.idea*

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/tests/test-wp-term-timestamps.php
+++ b/tests/test-wp-term-timestamps.php
@@ -81,29 +81,22 @@ class WP_Term_Timestamp_Tests extends WP_UnitTestCase {
 		/**
 		 * Get the $created_meta_key, after filters have been applied
 		 */
-		$created_meta_key = apply_filters( 'wp_term_timestamps_created_meta_key', 'created', $term_id, 'category' );
+		$created_by_meta_key = apply_filters( 'wp_term_timestamps_created_by_meta_key', 'created_by', $term_id, 'category' );
+		$created_timestamp_meta_key = apply_filters( 'wp_term_timestamps_created_timestamp_key', 'created_timestamp', $term_id, 'category' );
 
 		/**
 		 * Get the term_meta for the created term
 		 */
-		$actual = get_term_meta( $term_id, $created_meta_key, false );
+		$actual_created_by = get_term_meta( $term_id, $created_by_meta_key, true );
+		$actual_created_timestamp = get_term_meta( $term_id, $created_timestamp_meta_key, true );
 
 		/**
 		 * Ensure there is some data stored in the term_meta
 		 */
-		$this->assertNotEmpty( $actual );
-
-		/**
-		 * Ensure that the timestamp is a valid timestamp
-		 */
-		$this->assertNotEmpty( $actual[0]['timestamp'] );
-		$this->assertNotFalse( strtotime($actual[0]['timestamp']) );
-
-		/**
-		 * Ensure that the user_id is populated and is the same as the user that created the term
-		 */
-		$this->assertNotEmpty( $actual[0]['user_id'] );
-		$this->assertEquals( $actual[0]['user_id'], $this->admin );
+		$this->assertNotEmpty( $actual_created_timestamp );
+		$this->assertNotFalse( strtotime( $actual_created_timestamp ) );
+		$this->assertNotEmpty( $actual_created_by );
+		$this->assertEquals( $actual_created_by, $this->admin );
 
 		/**
 		 * Update the term
@@ -113,7 +106,7 @@ class WP_Term_Timestamp_Tests extends WP_UnitTestCase {
 		/**
 		 * Get the $modified_meta_key, after filters have been applied
 		 */
-		$modified_meta_key = apply_filters( 'wp_term_timestamps_modified_meta_key', 'modified', $term_id, 'category' );
+		$modified_meta_key = apply_filters( 'wp_term_modifications_meta_key', 'modifications', $term_id, 'category' );
 
 		/**
 		 * Get the term_meta for the modified term
@@ -147,7 +140,7 @@ class WP_Term_Timestamp_Tests extends WP_UnitTestCase {
 		/**
 		 * Only run these tests if WPGraphQL is installed in the same environment where these tests are being run
 		 */
-		if ( function_exists( 'do_graphql_request' ) && defined( 'WPGRAPHQL_VERSION' ) && version_compare( WPGRAPHQL_VERSION, '0.0.12' ) >= 0  ) {
+		if ( function_exists( 'do_graphql_request' ) && defined( 'WPGRAPHQL_VERSION' ) && version_compare( WPGRAPHQL_VERSION, '0.0.12' ) >= 0 ) {
 
 			/**
 			 * Set the current user to someone with permission to create terms
@@ -226,6 +219,130 @@ class WP_Term_Timestamp_Tests extends WP_UnitTestCase {
 			 * Ensure the processed GraphQL request matches our expectation
 			 */
 			$this->assertEquals( $actual, $expected );
+
+			/**
+			 * Update the term twice so we can ensure that we output the latestModified and an array of modifications
+			 */
+			wp_update_term( $term_id, 'category', [ 'description' => 'updated description' ] );
+
+			/**
+			 * Wait a second before making the next update so the modified timestamps will be unique
+			 */
+			sleep(1);
+
+			/**
+			 * Update the term again
+			 */
+			wp_update_term( $term_id, 'category', [ 'description' => 'another updated description' ] );
+
+			/**
+			 * Query via GraphQL again
+			 */
+			$request = '
+			query getCategory($id:ID!){
+				category(id:$id){
+					id
+					name
+					categoryId
+					lastModified {
+						user {
+							userId
+						}
+						time
+					}
+					modifications {
+						user{
+							userId
+						}
+						time
+					}
+				}
+			}
+			';
+
+			/**
+			 * Define the variables for the GraphQL request
+			 */
+			$variables = [
+				'id' => $global_id
+			];
+
+			/**
+			 * Process the GraphQL query
+			 */
+			$actual = do_graphql_request( $request, 'getCategory', $variables );
+
+			/**
+			 * Ensure the graphql request returns something
+			 */
+			$this->assertNotEmpty( $actual );
+
+			/**
+			 * Ensure the userId is returned
+			 */
+			$this->assertNotEmpty( $actual['data']['category']['lastModified']['user']['userId'] );
+
+			/**
+			 * Ensure the userId is the admin's user ID
+			 */
+			$this->assertEquals( $actual['data']['category']['lastModified']['user']['userId'], $this->admin );
+
+			/**
+			 * Ensure there's a timestamp
+			 */
+			$this->assertNotEmpty( $actual['data']['category']['lastModified']['time'] );
+
+			/**
+			 * Ensure the timestamp is a valid timestamp
+			 */
+			$this->assertNotFalse( strtotime( $actual['data']['category']['lastModified']['time'] ) );
+
+			/**
+			 * Ensure the userId is returned
+			 */
+			$this->assertNotEmpty( $actual['data']['category']['modifications'][0]['user']['userId'] );
+
+			/**
+			 * Ensure the userId is the admin's user ID
+			 */
+			$this->assertEquals( $actual['data']['category']['modifications'][0]['user']['userId'], $this->admin );
+
+			/**
+			 * Ensure there's a timestamp
+			 */
+			$this->assertNotEmpty( $actual['data']['category']['modifications'][0]['time'] );
+
+			/**
+			 * Ensure the timestamp is a valid timestamp
+			 */
+			$this->assertNotFalse( strtotime( $actual['data']['category']['modifications'][0]['time'] ) );
+
+			/**
+			 * Ensure the userId is returned for the 2nd modification
+			 */
+			$this->assertNotEmpty( $actual['data']['category']['modifications'][1]['user']['userId'] );
+
+			/**
+			 * Ensure the userId is the admin's user ID for the 2nd modification
+			 */
+			$this->assertEquals( $actual['data']['category']['modifications'][1]['user']['userId'], $this->admin );
+
+			/**
+			 * Ensure there's a timestamp
+			 */
+			$this->assertNotEmpty( $actual['data']['category']['modifications'][1]['time'] );
+
+			/**
+			 * Ensure the timestamp is a valid timestamp for the 2nd modification
+			 */
+			$this->assertNotFalse( strtotime( $actual['data']['category']['modifications'][1]['time'] ) );
+
+			/**
+			 * Ensure the order of the modifications is newest to oldest
+			 */
+			$modified0 = strtotime( $actual['data']['category']['modifications'][0]['time'] );
+			$modified1 = strtotime( $actual['data']['category']['modifications'][1]['time'] );
+			$this->assertTrue( $modified0 > $modified1 );
 
 		} else {
 


### PR DESCRIPTION
This closes #1 

- update .gitignore to ignore .idea files
- update plugin version
- update the meta_keys where we’re storing data to: “created_by”, “created_timestamp”, “modifications”, “last_modified_timestamp”, “last_modified_by” and applied filters to each of them
- updated output of columns to only affect taxonomies with “show_ui” set to true
- updated WPGraphQL fields to support “modifications” and “lastModified”
- updated unitTests to work with the new format of data storage